### PR TITLE
Improve sha-ness detection

### DIFF
--- a/lib/util.janet
+++ b/lib/util.janet
@@ -167,7 +167,7 @@
   (assert url "function requires :url argument")
   (assert dir "function requires :dir argument")
   (default tag "HEAD")
-  (def sha? (= [] (peg/match '(between 7 40 :h) tag)))
+  (def sha? (peg/match '(between 7 40 :h) tag))
   (def devnull (devnull))
   (def stdio {:out devnull :err devnull})
   (if (= "HEAD" tag)


### PR DESCRIPTION
This PR is an attempt to address #12.

With the change in this PR `jeep prep vendor` yielded:

```
$ jeep prep vendor
vendoring https://github.com/sogaiu/janet-peg to deps/janet-peg
  copying tmp/lib/location.janet to deps/janet-peg/lib/location.janet
Preparations completed.
```

...and examining the filesystem afterwards suggested that vendoring was successful.